### PR TITLE
Make Route 360 compatible with Zepto

### DIFF
--- a/src/extension/leaflet/layer/LeafletPolygonLayer.js
+++ b/src/extension/leaflet/layer/LeafletPolygonLayer.js
@@ -219,7 +219,7 @@ r360.LeafletPolygonLayer = L.Class.extend({
                 this.offset = { x : 0 , y : 0 };
 
             // adjust the offset after map panning / zooming
-            if ( typeof svgPosition != 'undefined' ) {
+            if ( svgPosition ) {
                 this.offset.x += (mapPosition.left - svgPosition.left) - this.extendWidthX/2;
                 this.offset.y += (mapPosition.top - svgPosition.top) - this.extendWidthY/2;
             }


### PR DESCRIPTION
In order to not have to pull in all of jQuery for my existing project which so far hasn't needed jQuery, I'm trying to use Zepto as a jQuery alternative.

The only difference between jQuery and Zepto that has caused a problem so far has been that .offset() returns `undefined` in jQuery and `null` in Zepto.