### PR TITLE
Update LeafletPolygonLayer.js

### DIFF
--- a/src/extension/leaflet/layer/LeafletPolygonLayer.js
+++ b/src/extension/leaflet/layer/LeafletPolygonLayer.js
@@ -264,7 +264,11 @@ r360.LeafletPolygonLayer = L.Class.extend({
             $('#canvas'+ $(this.map._container).attr("id") + '-' + this.id).append(!this.inverse ? r360.SvgUtil.getNormalSvgElement(gElements, options)
                                                                                  : r360.SvgUtil.getInverseSvgElement(gElements, options));
         }
-    }
+    },
+    
+    _layerAdd: function(options) {
+		this.onAdd(options.target);
+	}
 });
 
 r360.leafletPolygonLayer = function (options) {


### PR DESCRIPTION
In leaflet v.1.0.0rc1 when you do initialize polygon layer with "var layer = r360.leafletPolygonLayer()" and then add it to map with "layer.addTo(this.map);" it throws an exception because it tries to call "_layerAdd" on layer to inform layer that it was added to map.
That's why I propose to add "_layerAdd" function that will redirect call to "onAdd" function